### PR TITLE
Migrate to official Timeless API

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,28 +4,31 @@ AI agent skills for [Timeless](https://timeless.day) meeting data.
 
 Published on [ClawHub](https://clawhub.ai/eilonmore/timeless).
 
+Uses the [official Timeless API](https://docs.timeless.day/) where available, with the unofficial API for extended features (AI chat, room management, share URL resolution, scheduling).
+
 ## What it does
 
 - Search and list meetings, rooms, transcripts, AI summaries
+- Fetch AI-generated documents (summaries, action items) in multiple formats
 - Upload audio/video recordings for transcription
 - Chat with Timeless AI about meeting content
 - Capture podcast episodes and YouTube videos into Timeless
 - Schedule meetings with productivity-first slot selection and curated invite links
-- Build automations with cron polling patterns
+- Automate workflows with webhooks or cron polling
 - Create and manage rooms, add/remove conversations
 
 ## Skills
 
 | Skill | Description |
 |-------|-------------|
-| [timeless-api](timeless-api/SKILL.md) | Meetings, rooms, transcripts, capture, automation |
+| [timeless-api](timeless-api/SKILL.md) | Meetings, rooms, transcripts, documents, uploads, webhooks, capture, automation |
 | [timeless-scheduling](timeless-scheduling/SKILL.md) | Meeting scheduling with smart slot selection |
 
 ## Shared Files
 
 | File | Description |
 |------|-------------|
-| [api-reference.md](api-reference.md) | Full Timeless API endpoint documentation |
+| [api-reference.md](api-reference.md) | Full API reference (official + unofficial endpoints) |
 | [scripts/](scripts/) | Helper scripts for uploads, podcasts, YouTube |
 
 ## Setup

--- a/api-reference.md
+++ b/api-reference.md
@@ -1,172 +1,591 @@
-# Timeless Unofficial API Reference
+# Timeless API Reference
 
-**Version**: Pre-release (internal endpoints)  
-**Base URL**: `https://my.timeless.day`  
-**Last Updated**: March 4, 2026
+**Last Updated**: April 9, 2026
 
-> ⚠️ This documents Timeless's internal API endpoints that can be used for programmatic access before the official public API launches. These endpoints may change without notice.
+This document covers both the **official** Timeless API and the **unofficial** API for extended features.
 
 ---
 
-## Authentication
+## Part 1: Official API
 
-All requests require a session token in the `Authorization` header:
+**Base URL**: `https://api.timeless.day/v1`  
+**Docs**: [docs.timeless.day](https://docs.timeless.day/)
+
+### Authentication
 
 ```
-Authorization: Token YOUR_TOKEN
+Authorization: Bearer YOUR_TOKEN
 ```
 
-### How to Get Your Token
+Get your token at [my.timeless.day/api-token](https://my.timeless.day/api-token). Tokens are 64-character hex strings.
 
-1. Go to [my.timeless.day/api-token](https://my.timeless.day/api-token)
-2. Copy the access token
+### Error Format
 
-> This token is tied to your user account. It may expire; grab a fresh one from the same page if you get 401 errors.
+All errors return a structured JSON body:
+
+```json
+{
+  "error": {
+    "code": "not_found",
+    "message": "Resource not found"
+  }
+}
+```
+
+Validation errors include a `details` array:
+
+```json
+{
+  "error": {
+    "code": "bad_request",
+    "message": "Request validation failed",
+    "details": [
+      { "field": "limit", "message": "Input should be less than or equal to 100" }
+    ]
+  }
+}
+```
+
+| Status | Code | Description |
+|--------|------|-------------|
+| 400 | `bad_request` | Invalid request parameters or body |
+| 401 | `unauthorized` | Missing or invalid API token |
+| 403 | `forbidden` | Token is valid but lacks permission |
+| 404 | `not_found` | Resource does not exist or is not accessible |
+| 429 | `rate_limited` | Too many requests |
+| 500 | `internal_error` | Unexpected server error |
+
+### Rate Limiting
+
+| Endpoint | Limit |
+|----------|-------|
+| Most endpoints | 60 requests/minute |
+| Webhook creation | 20 requests/minute |
+| File upload | 10 requests/minute |
+
+Every response includes: `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`
+
+When rate limited, a `Retry-After` header indicates seconds to wait.
+
+### Pagination
+
+List endpoints use cursor-based pagination:
+
+```json
+{
+  "data": [...],
+  "next_cursor": "eyJjcmV...",
+  "has_more": true
+}
+```
+
+Pass `cursor` as a query parameter to get the next page. Control page size with `limit` (1-100, default 25).
+
+### Resource IDs
+
+All resources use prefixed IDs:
+
+| Resource | Prefix | Example |
+|----------|--------|---------|
+| Meeting | `mtg_` | `mtg_abc123` |
+| Room | `room_` | `room_abc123` |
+| Document | `doc_` | `doc_abc123` |
+| User | `usr_` | `usr_abc123` |
+| Speaker | `spk_` | `spk_abc123` |
+| Webhook | `whk_` | `whk_abc123` |
 
 ---
-
-## Endpoints
 
 ### 1. List Meetings
 
 ```
-GET /api/v1/spaces/meeting/
+GET /meetings
 ```
 
-Returns a paginated list of your meetings.
+Returns a paginated list of meetings accessible to the authenticated user.
 
 #### Query Parameters
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `include` | string | ✅ | `owned` (your meetings) or `shared` (shared with you) |
-| `search` | string | | Search by meeting title or attendees |
+| `scope` | string | | `all` (default), `owned`, or `shared` |
+| `search` | string | | Search by meeting title (substring match) |
+| `q` | string | | Semantic search across meeting content |
 | `start_date` | string | | From date (`YYYY-MM-DD`) |
 | `end_date` | string | | To date (`YYYY-MM-DD`) |
-| `status` | string | | Filter by status: `COMPLETED`, `SCHEDULED`, `PROCESSING`, `FAILED`, etc. |
-| `page` | integer | | Page number (default: 1) |
-| `per_page` | integer | | Results per page (default: 20) |
+| `status` | string | | `completed`, `processing`, `scheduled`, `failed` |
+| `participant` | string | | Filter by participant name or email |
+| `company` | string | | Filter by company name or domain |
+| `room_id` | string | | Filter by room ID (e.g. `room_abc123`) |
+| `id` | string | | Filter by meeting ID(s). Pass multiple: `?id=mtg_abc&id=mtg_def` |
+| `expand` | string | | `documents` to include AI documents inline |
+| `limit` | integer | | Results per page, 1-100 (default: 25) |
+| `cursor` | string | | Pagination cursor from previous response |
 
 #### Example
 
 ```bash
-# List your completed meetings from the last week
-curl -s "https://my.timeless.day/api/v1/spaces/meeting/?include=owned&status=COMPLETED&start_date=2026-02-25&end_date=2026-03-04&per_page=50" \
-  -H "Authorization: Token $TIMELESS_TOKEN"
+curl -s "https://api.timeless.day/v1/meetings?scope=owned&status=completed&start_date=2026-02-25&end_date=2026-03-04&limit=50" \
+  -H "Authorization: Bearer $TIMELESS_ACCESS_TOKEN"
 ```
 
 #### Response
 
 ```json
 {
-  "count": 42,
-  "next": "https://my.timeless.day/api/v1/spaces/meeting/?page=2",
-  "previous": null,
-  "results": [
+  "data": [
     {
-      "uuid": "abc123",
+      "id": "mtg_abc123",
       "title": "Weekly Standup",
-      "start_ts": "2026-03-03T10:00:00Z",
-      "end_ts": "2026-03-03T10:45:00Z",
-      "status": "COMPLETED",
-      "primary_conversation_uuid": "conv-456",
-      "conversation_source": "VIDEO_CONFERENCE_BOT_RECORDER",
-      "host_user": {
-        "uuid": "user-123",
-        "email": "you@company.com",
-        "first_name": "Your",
-        "last_name": "Name"
+      "status": "completed",
+      "source": "google_meet",
+      "start_time": "2026-03-03T10:00:00Z",
+      "end_time": "2026-03-03T10:45:00Z",
+      "duration": 2700,
+      "host": {
+        "id": "usr_123",
+        "name": "Your Name",
+        "email": "you@company.com"
       },
+      "participants": [
+        { "name": "Alice", "email": "alice@co.com", "title": "Engineer", "company": "Acme Corp" }
+      ],
       "created_at": "2026-03-03T09:55:00Z"
     }
-  ]
+  ],
+  "next_cursor": "eyJjcmVhdGVkX2F0Ijo...",
+  "has_more": true
 }
 ```
 
 **Key fields:**
-- `uuid`: The space UUID (use this to get full details via Get Space)
-- `primary_conversation_uuid`: Use this to fetch the transcript
-- `status`: `COMPLETED` means transcript is ready
-
-> **To get all meetings (owned + shared):** Make two requests, one with `include=owned` and one with `include=shared`, then merge results.
+- `id`: Meeting ID (use for transcripts, recordings, documents)
+- `status`: `completed` means transcript is ready
+- `source`: `google_meet`, `zoom`, `teams`, `slack`, `whatsapp`, `phone`, `upload`, `desktop`
 
 ---
 
 ### 2. List Rooms
 
 ```
-GET /api/v1/spaces/room/
+GET /rooms
 ```
 
-Returns a paginated list of your rooms (collaborative spaces containing multiple meetings).
+Returns a paginated list of rooms.
 
 #### Query Parameters
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `include` | string | ✅ | `owned` or `shared` |
+| `scope` | string | | `all` (default), `owned`, or `shared` |
 | `search` | string | | Search by room title |
-| `page` | integer | | Page number (default: 1) |
-| `per_page` | integer | | Results per page (default: 20) |
+| `id` | string | | Filter by room ID(s) |
+| `expand` | string | | `documents`, `meetings`, or both |
+| `limit` | integer | | Results per page, 1-100 (default: 25) |
+| `cursor` | string | | Pagination cursor |
 
 #### Example
 
 ```bash
-curl -s "https://my.timeless.day/api/v1/spaces/room/?include=owned" \
-  -H "Authorization: Token $TIMELESS_TOKEN"
+curl -s "https://api.timeless.day/v1/rooms?scope=owned&expand=meetings" \
+  -H "Authorization: Bearer $TIMELESS_ACCESS_TOKEN"
 ```
 
 #### Response
 
 ```json
 {
-  "count": 8,
-  "results": [
+  "data": [
     {
-      "uuid": "room-123",
-      "title": "Project Alpha",
-      "host_user": {
-        "uuid": "user-123",
-        "email": "you@company.com",
-        "first_name": "Your",
-        "last_name": "Name"
-      },
-      "created_at": "2026-02-15T14:00:00Z"
+      "id": "room_abc123",
+      "title": "Engineering standups",
+      "created_at": "2025-01-01T00:00:00Z",
+      "updated_at": "2025-01-15T10:30:00Z",
+      "meeting_count": 42,
+      "meetings": [
+        {
+          "id": "mtg_abc123",
+          "title": "Weekly standup",
+          "status": "completed",
+          "source": "google_meet",
+          "start_time": "2025-01-15T10:00:00Z",
+          "duration": 1800
+        }
+      ]
+    }
+  ],
+  "next_cursor": null,
+  "has_more": false
+}
+```
+
+---
+
+### 3. Get Transcript
+
+```
+GET /meetings/{meeting_id}/transcript
+```
+
+Returns the transcript for a meeting with speaker identification and timestamps.
+
+#### Example
+
+```bash
+curl -s "https://api.timeless.day/v1/meetings/mtg_abc123/transcript" \
+  -H "Authorization: Bearer $TIMELESS_ACCESS_TOKEN"
+```
+
+#### Response
+
+```json
+{
+  "meeting_id": "mtg_abc123",
+  "language": "en",
+  "speakers": [
+    { "id": "spk_001", "name": "Alice Johnson" },
+    { "id": "spk_002", "name": "Bob Smith" }
+  ],
+  "segments": [
+    {
+      "speaker_id": "spk_001",
+      "start_time": 0,
+      "end_time": 4.5,
+      "text": "Good morning everyone, let's get started."
+    },
+    {
+      "speaker_id": "spk_002",
+      "start_time": 4.8,
+      "end_time": 8.2,
+      "text": "Sounds good. I have updates on the project."
     }
   ]
 }
 ```
 
-> Rooms don't have `start_ts`, `end_ts`, or `status` fields. To see the meetings inside a room, use **Get Space**.
+**Formatting the transcript:**
+
+Map each segment's `speaker_id` to the `speakers` array:
+
+```
+[00:00:00] Alice Johnson: Good morning everyone, let's get started.
+[00:00:04] Bob Smith: Sounds good. I have updates on the project.
+```
 
 ---
 
-### 3. Get Space (Meeting or Room Details)
+### 4. Get Recording URL
+
+```
+GET /meetings/{meeting_id}/recording
+```
+
+Returns a temporary signed URL to download the recording.
+
+#### Example
+
+```bash
+curl -s "https://api.timeless.day/v1/meetings/mtg_abc123/recording" \
+  -H "Authorization: Bearer $TIMELESS_ACCESS_TOKEN"
+```
+
+#### Response
+
+```json
+{
+  "meeting_id": "mtg_abc123",
+  "recording_url": "https://storage.example.com/recordings/abc123?token=..."
+}
+```
+
+> `recording_url` is `null` if no recording is available. The URL is time-limited.
+
+---
+
+### 5. Get Document
+
+```
+GET /documents/{document_id}
+```
+
+Returns an AI-generated document (summary, action items, notes) in your chosen format.
+
+#### Query Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `format` | string | | `html` (default), `markdown`, `raw`, `docx`, `json` |
+
+#### Example
+
+```bash
+curl -s "https://api.timeless.day/v1/documents/doc_abc123?format=markdown" \
+  -H "Authorization: Bearer $TIMELESS_ACCESS_TOKEN"
+```
+
+#### Response
+
+```json
+{
+  "id": "doc_abc123",
+  "title": "Meeting summary",
+  "format": "markdown",
+  "content": "# Weekly standup\n\n## Key decisions\n- Proceed with the new API design\n\n## Action items\n- Alice: Update the spec by Friday\n",
+  "created_at": "2025-01-15T10:35:00Z"
+}
+```
+
+> For `docx` format, `content` is base64-encoded. For `json`, it is a JSON-serialized array of content blocks.
+
+---
+
+### 6. Upload Media
+
+```
+PUT /meetings/upload
+```
+
+Upload an audio or video file for transcription. Send the raw binary file as the request body (not multipart form data).
+
+#### Query Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `title` | string | | Title for the recording (max 500 chars) |
+| `language` | string | | Language code (e.g. `en`, `es`) |
+
+#### Headers
+
+| Header | Required | Description |
+|--------|----------|-------------|
+| `Content-Type` | Yes | MIME type of the file |
+
+**Supported audio:** `audio/mpeg`, `audio/mp4`, `audio/wav`, `audio/webm`, `audio/ogg`, `audio/aac`, `audio/flac`  
+**Supported video:** `video/mp4`, `video/webm`, `video/ogg`, `video/quicktime`
+
+#### Example
+
+```bash
+curl -X PUT "https://api.timeless.day/v1/meetings/upload?title=Team%20sync&language=en" \
+  -H "Authorization: Bearer $TIMELESS_ACCESS_TOKEN" \
+  -H "Content-Type: audio/mpeg" \
+  --data-binary @recording.mp3
+```
+
+#### Response
+
+```json
+{
+  "id": "mtg_abc123",
+  "status": "processing"
+}
+```
+
+Poll `GET /meetings?id=mtg_abc123` until `status` changes from `processing` to `completed`.
+
+Rate limit: 10 requests per minute.
+
+---
+
+### 7. Webhooks
+
+#### Create Webhook
+
+```
+POST /webhooks
+```
+
+```bash
+curl -X POST "https://api.timeless.day/v1/webhooks" \
+  -H "Authorization: Bearer $TIMELESS_ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "url": "https://example.com/webhooks/timeless",
+    "events": ["meeting.transcript_ready", "meeting.initial_summary_ready"]
+  }'
+```
+
+**Request Body:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `url` | string | Yes | HTTPS URL to receive events (max 2048 chars) |
+| `events` | array | Yes | At least one of: `meeting.transcript_ready`, `meeting.initial_summary_ready` |
+| `enabled` | boolean | | Default `true`. Set `false` to create disabled. |
+
+**Response:**
+
+```json
+{
+  "id": "whk_abc123",
+  "url": "https://example.com/webhooks/timeless",
+  "events": ["meeting.transcript_ready", "meeting.initial_summary_ready"],
+  "enabled": true,
+  "secret": "a1b2c3d4e5f6...",
+  "created_at": "2025-01-15T12:00:00Z",
+  "updated_at": "2025-01-15T12:00:00Z"
+}
+```
+
+> Store `secret` securely. It is only returned at creation time.
+
+#### List Webhooks
+
+```
+GET /webhooks
+```
+
+```bash
+curl -s "https://api.timeless.day/v1/webhooks" \
+  -H "Authorization: Bearer $TIMELESS_ACCESS_TOKEN"
+```
+
+#### Update Webhook
+
+```
+PATCH /webhooks/{webhook_id}
+```
+
+Only include fields you want to change.
+
+```bash
+curl -X PATCH "https://api.timeless.day/v1/webhooks/whk_abc123" \
+  -H "Authorization: Bearer $TIMELESS_ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"enabled": false}'
+```
+
+#### Delete Webhook
+
+```
+DELETE /webhooks/{webhook_id}
+```
+
+```bash
+curl -X DELETE "https://api.timeless.day/v1/webhooks/whk_abc123" \
+  -H "Authorization: Bearer $TIMELESS_ACCESS_TOKEN"
+```
+
+#### Webhook Signature Verification
+
+Every delivery includes `X-Webhook-Signature: sha256=<hex digest>`. Verify with HMAC-SHA256:
+
+```python
+import hashlib, hmac
+
+def verify_signature(payload: bytes, signature_header: str, secret: str) -> bool:
+    expected = hmac.new(secret.encode(), payload, hashlib.sha256).hexdigest()
+    received = signature_header.removeprefix("sha256=")
+    return hmac.compare_digest(expected, received)
+```
+
+```javascript
+const crypto = require("crypto");
+
+function verifySignature(payload, signatureHeader, secret) {
+  const expected = crypto.createHmac("sha256", secret).update(payload).digest("hex");
+  const received = signatureHeader.replace("sha256=", "");
+  return crypto.timingSafeEqual(Buffer.from(expected), Buffer.from(received));
+}
+```
+
+**Delivery behavior:** 10s timeout. Retries up to 3 times (1s, 10s, 60s) on 5xx, 429, and network failures. 4xx (except 429) are not retried.
+
+---
+
+### Meeting Status Values (Official API)
+
+| Status | Description |
+|--------|-------------|
+| `completed` | Meeting processed, transcript ready |
+| `scheduled` | Meeting scheduled for the future |
+| `processing` | Transcription in progress |
+| `failed` | Processing failed |
+
+### Meeting Sources (Official API)
+
+| Source | Description |
+|--------|-------------|
+| `google_meet` | Google Meet |
+| `zoom` | Zoom |
+| `teams` | Microsoft Teams |
+| `slack` | Slack huddle |
+| `whatsapp` | WhatsApp voice message |
+| `phone` | Phone call |
+| `upload` | Uploaded file |
+| `desktop` | Desktop app recording |
+
+---
+
+## Part 2: Unofficial API (Extended Features)
+
+> These endpoints provide capabilities not yet available in the official API: space details, AI chat, room management, share URL resolution, and scheduling.
+
+**Base URL**: `https://my.timeless.day`
+
+### Authentication
+
+```
+Authorization: Token YOUR_TOKEN
+```
+
+The same token from [my.timeless.day/api-token](https://my.timeless.day/api-token) works for both APIs. The header format differs: `Bearer` for official, `Token` for unofficial.
+
+### Rate Limits
+
+No official rate limits documented. Be respectful:
+- Add 0.5s delay between sequential requests
+- Max ~60 requests per minute
+- Use pagination instead of fetching everything at once
+
+### Pagination
+
+Unofficial API uses page-based pagination:
+
+```json
+{
+  "count": 42,
+  "next": "https://my.timeless.day/api/v1/spaces/meeting/?page=2",
+  "previous": null,
+  "results": [...]
+}
+```
+
+### Error Handling
+
+| Code | Meaning |
+|------|---------|
+| 401 | Token expired or invalid. Re-authenticate. |
+| 403 | No access to this resource. Try workspace/public endpoints. |
+| 404 | Resource not found. |
+| 429 | Rate limited. Back off and retry. |
+| 500 | Server error. Retry with exponential backoff. |
+
+---
+
+### 8. Get Space (Meeting or Room Details)
 
 ```
 GET /api/v1/spaces/{uuid}/
 ```
 
-Returns the full details for any space (meeting or room), including conversations, AI-generated documents, contacts, and organizations.
+Returns full details for any space including conversations, AI artifacts, contacts, organizations, and chat threads. No official equivalent.
 
-#### Choosing the Right Endpoint
-
-Timeless has three access levels for spaces. Try them in this order:
+#### Access Levels
 
 | # | Endpoint | When to Use |
 |---|----------|-------------|
 | 1 | `GET /api/v1/spaces/{uuid}/` | Your own spaces (private) |
-| 2 | `GET /api/v1/spaces/{uuid}/workspace/?host_uuid={hostUuid}` | Spaces shared within your workspace. **`host_uuid` is required** (get it from `host_user.uuid` in the list response). |
+| 2 | `GET /api/v1/spaces/{uuid}/workspace/?host_uuid={hostUuid}` | Shared within workspace. `host_uuid` required. |
 | 3 | `GET /api/v1/spaces/public/{uuid}/{hostUuid}/` | Publicly shared spaces |
 
-If endpoint 1 returns 401/403/404, try endpoint 2. If that also fails, try endpoint 3.
+Try in order. If one returns 401/403/404, try the next.
 
 #### Example
 
 ```bash
-# Private space
 curl -s "https://my.timeless.day/api/v1/spaces/abc123/" \
-  -H "Authorization: Token $TIMELESS_TOKEN"
+  -H "Authorization: Token $TIMELESS_ACCESS_TOKEN"
 ```
 
 #### Response
@@ -207,14 +626,14 @@ curl -s "https://my.timeless.day/api/v1/spaces/abc123/" \
     {
       "uuid": "contact-1",
       "name": "Alice",
-      "conversations": [{ "uuid": "conv-456", "..." : "..." }]
+      "conversations": [{ "uuid": "conv-456" }]
     }
   ],
   "organizations": [
     {
       "uuid": "org-1",
       "name": "Acme Corp",
-      "conversations": [{ "uuid": "conv-456", "..." : "..." }]
+      "conversations": [{ "uuid": "conv-456" }]
     }
   ],
   "threads": [
@@ -228,31 +647,26 @@ curl -s "https://my.timeless.day/api/v1/spaces/abc123/" \
 ```
 
 **Key fields:**
-- `conversations[]`: All conversations (recordings) in this space. For meetings, typically one. For rooms, can be many.
-- `artifacts[]`: AI-generated documents. The `type` field tells you what it is (e.g., `summary`). Content is in `content.body` (HTML).
-- `contacts[]` and `organizations[]`: Each contains nested `conversations[]` for meetings associated with that contact/org.
-- `threads[]`: AI chat threads. Use `threads[0].uuid` if you want to chat with the space agent.
+- `conversations[]`: All recordings in this space. For meetings, typically one. For rooms, can be many.
+- `artifacts[]`: AI-generated documents. `type` tells you what it is (e.g. `summary`). Content in `content.body` (HTML).
+- `contacts[]` and `organizations[]`: Each contains nested `conversations[]`.
+- `threads[]`: AI chat threads. Use `threads[0].uuid` to chat with the space agent.
 
 ---
 
-### 4. Get Transcript
+### 9. Get Transcript by Conversation UUID
 
 ```
 GET /api/v1/conversation/{conversation_uuid}/transcript/
 ```
 
-Returns the full speaker-attributed transcript for a conversation.
-
-#### How to Get the Conversation UUID
-
-- From **List Meetings**: use the `primary_conversation_uuid` field
-- From **Get Space**: use `conversations[].uuid`
+Returns the transcript for a specific conversation. Use this when you have a conversation UUID from Get Space (e.g. for room conversations). For meeting-level transcripts, prefer the official `GET /meetings/{id}/transcript`.
 
 #### Example
 
 ```bash
 curl -s "https://my.timeless.day/api/v1/conversation/conv-456/transcript/" \
-  -H "Authorization: Token $TIMELESS_TOKEN"
+  -H "Authorization: Token $TIMELESS_ACCESS_TOKEN"
 ```
 
 #### Response
@@ -265,46 +679,30 @@ curl -s "https://my.timeless.day/api/v1/conversation/conv-456/transcript/" \
       "start_time": 0.5,
       "end_time": 3.2,
       "speaker_id": "speaker_0"
-    },
-    {
-      "text": "I'll share the roadmap updates.",
-      "start_time": 3.5,
-      "end_time": 5.8,
-      "speaker_id": "speaker_1"
     }
   ],
   "speakers": [
-    { "id": "speaker_0", "name": "Alice Johnson" },
-    { "id": "speaker_1", "name": "Bob Smith" }
+    { "id": "speaker_0", "name": "Alice Johnson" }
   ],
   "language": "he"
 }
 ```
 
-**Formatting the transcript:**
-
-Map each item's `speaker_id` to the `speakers` array to get human-readable output:
-
-```
-[00:00:00] Alice Johnson: Good morning everyone, let's get started.
-[00:00:03] Bob Smith: I'll share the roadmap updates.
-```
-
 ---
 
-### 5. Get Recording URL
+### 10. Get Recording URL by Conversation UUID
 
 ```
 GET /api/v1/conversation/{conversation_uuid}/recording/
 ```
 
-Returns a time-limited signed URL to the audio/video recording.
+Returns a time-limited signed URL. For meeting-level recordings, prefer the official `GET /meetings/{id}/recording`.
 
 #### Example
 
 ```bash
 curl -s "https://my.timeless.day/api/v1/conversation/conv-456/recording/" \
-  -H "Authorization: Token $TIMELESS_TOKEN"
+  -H "Authorization: Token $TIMELESS_ACCESS_TOKEN"
 ```
 
 #### Response
@@ -315,70 +713,11 @@ curl -s "https://my.timeless.day/api/v1/conversation/conv-456/recording/" \
 }
 ```
 
-> The URL expires after a short time. Fetch it when you need it, don't cache it.
-
 ---
 
-### 6. Upload a Recording
+### 11. Resolve a Timeless Share URL
 
-Upload an audio/video file for transcription and AI processing. This is a 3-step flow.
-
-#### Step 1: Get a Presigned Upload URL
-
-```bash
-curl -X POST "https://my.timeless.day/api/v1/conversation/storage/presigned-url/" \
-  -H "Authorization: Token $TIMELESS_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "file_name": "team-meeting.mp3",
-    "file_type": "audio/mpeg"
-  }'
-```
-
-**Response:**
-```json
-{
-  "url": "https://storage.googleapis.com/..."
-}
-```
-
-#### Step 2: Upload the File
-
-```bash
-curl -X PUT "PRESIGNED_URL_FROM_STEP_1" \
-  -H "Content-Type: audio/mpeg" \
-  --upload-file team-meeting.mp3
-```
-
-#### Step 3: Trigger Processing
-
-```bash
-curl -X POST "https://my.timeless.day/api/v1/conversation/process/media/" \
-  -H "Authorization: Token $TIMELESS_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "language": "he",
-    "filename": "Team Meeting March 4"
-  }'
-```
-
-**Response:**
-```json
-{
-  "event_uuid": "evt-abc123",
-  "space_uuid": "space-xyz789"
-}
-```
-
-After processing completes (poll `GET /api/v1/spaces/{space_uuid}/` until `is_processing` is `false`), the transcript and AI summary will be available.
-
-**Supported formats:** mp3, wav, m4a, mp4, webm, ogg
-
----
-
-### 7. Resolve a Timeless Share URL
-
-Timeless URLs like `https://my.timeless.day/m/ENCODED_ID` contain two Base64-encoded short IDs (22 characters each), concatenated as `spaceId + hostId`.
+URLs like `https://my.timeless.day/m/ENCODED_ID` contain two Base64-encoded short IDs (22 characters each), concatenated as `spaceId + hostId`.
 
 #### Decoding Logic
 
@@ -396,7 +735,6 @@ def decode_timeless_url(url):
 ```
 
 ```javascript
-// Node.js / JavaScript
 function decodeTimelessUrl(url) {
   const encoded = url.replace(/\/$/, '').split('/m/').pop();
   const combined = Buffer.from(encoded, 'base64').toString();
@@ -408,33 +746,29 @@ function decodeTimelessUrl(url) {
 ```
 
 ```bash
-# Shell
 ENCODED="the_part_after_/m/"
 DECODED=$(echo "$ENCODED" | base64 -d)
 SPACE_ID=$(echo "$DECODED" | cut -c1-22)
 HOST_ID=$(echo "$DECODED" | cut -c23-44)
 ```
 
-Once decoded, use the space ID with the **Get Space** endpoints (try private → workspace → public, as described in section 3).
+Once decoded, use the space ID with Get Space (try private, workspace, public in order).
 
 ---
 
-### 8. Chat with Meeting AI
+### 12. Chat with Meeting AI
 
 ```
 POST /api/v1/agent/space/chat/
 ```
 
-Send a question to Timeless's AI agent about a meeting or room.
-
-> ⚠️ This endpoint is **asynchronous**. It returns `204 No Content` immediately. The AI response arrives via WebSocket/Pusher. For programmatic use, poll the thread for the response.
+Send a question to the AI agent about a meeting or room. This is asynchronous: it returns `204 No Content` immediately. Poll the thread for the response.
 
 #### Example
 
 ```bash
-# Send a question
 curl -X POST "https://my.timeless.day/api/v1/agent/space/chat/" \
-  -H "Authorization: Token $TIMELESS_TOKEN" \
+  -H "Authorization: Token $TIMELESS_ACCESS_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
     "space_uuid": "abc123",
@@ -449,78 +783,93 @@ curl -X POST "https://my.timeless.day/api/v1/agent/space/chat/" \
   }'
 ```
 
+Get `thread_uuid` from the space's `threads[0].uuid` (via Get Space).
+
 #### Polling for the Response
 
 ```bash
-# Poll the thread until is_running becomes false
 curl -s "https://my.timeless.day/api/v1/agent/threads/thread-1/" \
-  -H "Authorization: Token $TIMELESS_TOKEN"
+  -H "Authorization: Token $TIMELESS_ACCESS_TOKEN"
 ```
 
-The thread response includes a `messages` array with all messages (user + AI). The last message with `role: "assistant"` is the AI's response. Keep polling every 2-3 seconds until `is_running: false`.
+Poll every 2-3 seconds until `is_running: false`. The last message with `role: "assistant"` is the AI's response.
 
 ---
 
-## Common Workflows
-
-### Workflow 1: Export All Meeting Transcripts
+### 13. Create a Room
 
 ```
-1. GET /api/v1/spaces/meeting/?include=owned&status=COMPLETED&per_page=100
-   → Collect all meeting UUIDs and primary_conversation_uuids
-   → Paginate through all pages using the `next` URL
-
-2. For each meeting:
-   GET /api/v1/conversation/{primary_conversation_uuid}/transcript/
-   → Save transcript with speaker names
-
-3. (Optional) For AI summaries:
-   GET /api/v1/spaces/{uuid}/
-   → Extract artifacts[] where type == "summary"
+POST /api/v1/spaces/
 ```
 
-### Workflow 2: Get All Conversations in a Room
+Create a new room for grouping meetings.
 
-```
-1. GET /api/v1/spaces/{room_uuid}/
-   → Response contains conversations[], contacts[], organizations[]
+#### Example
 
-2. Collect ALL unique conversation UUIDs from:
-   - space.conversations[].uuid
-   - space.contacts[].conversations[].uuid  
-   - space.organizations[].conversations[].uuid
-   (Deduplicate by UUID)
-
-3. For each conversation UUID:
-   GET /api/v1/conversation/{uuid}/transcript/
-   → Fetch the transcript
+```bash
+curl -X POST "https://my.timeless.day/api/v1/spaces/" \
+  -H "Authorization: Token $TIMELESS_ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "has_onboarded": true,
+    "space_type": "ROOM",
+    "title": "Project Alpha"
+  }'
 ```
 
-### Workflow 3: Search Meetings and Get Transcripts
+#### Request Body
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `has_onboarded` | boolean | Yes | Always `true` |
+| `space_type` | string | Yes | Always `"ROOM"` |
+| `title` | string | Yes | Room title |
+
+Returns the full space object. Extract `uuid` for subsequent operations.
+
+---
+
+### 14. Add Resource to Room
 
 ```
-1. GET /api/v1/spaces/meeting/?include=owned&search=quarterly+review
-   → Find meetings matching your search
-
-2. Pick the meeting you want, take its primary_conversation_uuid
-
-3. GET /api/v1/conversation/{primary_conversation_uuid}/transcript/
-   → Full speaker-attributed transcript
+POST /api/v1/spaces/{space_uuid}/resources/
 ```
 
-### Workflow 4: Resolve a Shared Link and Read It
+Attach a conversation to a room.
 
-```
-1. Decode the /m/ URL (see section 7)
-2. Try GET /api/v1/spaces/{space_uuid}/
-3. If 40x, try GET /api/v1/spaces/{space_uuid}/workspace/?host_uuid={host_uuid}
-4. If 40x, try GET /api/v1/spaces/public/{space_uuid}/{host_uuid}/
-5. From the space response, get conversations and fetch transcripts
+```bash
+curl -X POST "https://my.timeless.day/api/v1/spaces/ROOM_UUID/resources/" \
+  -H "Authorization: Token $TIMELESS_ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "resource_type": "CONVERSATION",
+    "resource_uuid": "CONVERSATION_UUID"
+  }'
 ```
 
 ---
 
-## Status Values
+### 15. Remove Resource from Room
+
+```
+DELETE /api/v1/spaces/{space_uuid}/resources/
+```
+
+Remove a conversation from a room. Same request body as Add Resource.
+
+```bash
+curl -X DELETE "https://my.timeless.day/api/v1/spaces/ROOM_UUID/resources/" \
+  -H "Authorization: Token $TIMELESS_ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "resource_type": "CONVERSATION",
+    "resource_uuid": "CONVERSATION_UUID"
+  }'
+```
+
+---
+
+### Unofficial Status Values
 
 | Status | Description |
 |--------|-------------|
@@ -531,7 +880,7 @@ The thread response includes a `messages` array with all messages (user + AI). T
 | `IN_CALL` | Bot is currently recording |
 | `IN_WAITING_ROOM` | Bot waiting to be admitted |
 
-## Recording Sources
+### Unofficial Recording Sources
 
 | Source | Description |
 |--------|-------------|
@@ -547,109 +896,79 @@ The thread response includes a `messages` array with all messages (user + AI). T
 
 ---
 
-### 9. Create a Room
+## Common Workflows
+
+### Workflow 1: Export All Meeting Transcripts
 
 ```
-POST /api/v1/spaces/
+1. GET https://api.timeless.day/v1/meetings?scope=owned&status=completed&limit=100
+   -> Collect all meeting IDs
+   -> Paginate using next_cursor
+
+2. For each meeting:
+   GET https://api.timeless.day/v1/meetings/{id}/transcript
+   -> Save transcript with speaker names
+
+3. (Optional) For AI summaries:
+   GET https://api.timeless.day/v1/meetings?scope=owned&status=completed&expand=documents
+   -> Get document IDs from meetings, then:
+   GET https://api.timeless.day/v1/documents/{doc_id}?format=markdown
 ```
 
-Create a new room (collaborative space for grouping meetings).
-
-#### Example
-
-```bash
-curl -X POST "https://my.timeless.day/api/v1/spaces/" \
-  -H "Authorization: Token $TIMELESS_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "has_onboarded": true,
-    "space_type": "ROOM",
-    "title": "Project Alpha"
-  }'
-```
-
-#### Request Body
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `has_onboarded` | boolean | ✅ | Always `true` |
-| `space_type` | string | ✅ | Always `"ROOM"` for rooms |
-| `title` | string | ✅ | Room title |
-
-#### Response
-
-Returns the full space object (same schema as Get Space). Extract `uuid` for subsequent operations.
-
----
-
-### 10. Add Resource to Room
+### Workflow 2: Get All Conversations in a Room
 
 ```
-POST /api/v1/spaces/{space_uuid}/resources/
+1. GET https://my.timeless.day/api/v1/spaces/{room_uuid}/
+   -> Response contains conversations[], contacts[], organizations[]
+
+2. Collect ALL unique conversation UUIDs from:
+   - space.conversations[].uuid
+   - space.contacts[].conversations[].uuid
+   - space.organizations[].conversations[].uuid
+   (Deduplicate by UUID)
+
+3. For each conversation UUID:
+   GET https://my.timeless.day/api/v1/conversation/{uuid}/transcript/
+   -> Fetch the transcript
 ```
 
-Attach a conversation (meeting recording) to a room. Call once per conversation you want to add.
-
-#### Example
-
-```bash
-curl -X POST "https://my.timeless.day/api/v1/spaces/ROOM_UUID/resources/" \
-  -H "Authorization: Token $TIMELESS_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "resource_type": "CONVERSATION",
-    "resource_uuid": "CONVERSATION_UUID"
-  }'
-```
-
-#### Request Body
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `resource_type` | string | ✅ | `"CONVERSATION"` |
-| `resource_uuid` | string | ✅ | UUID of the conversation to attach |
-
-> **How to get conversation UUIDs:** From List Meetings, use `primary_conversation_uuid`. From Get Space, use `conversations[].uuid`.
-
----
-
-### 11. Remove Resource from Room
+### Workflow 3: Search Meetings and Get Summary
 
 ```
-DELETE /api/v1/spaces/{space_uuid}/resources/
+1. GET https://api.timeless.day/v1/meetings?q=quarterly+review&expand=documents
+   -> Find meetings matching your semantic search
+
+2. Pick the meeting, get its document IDs from documents[]
+
+3. GET https://api.timeless.day/v1/documents/{doc_id}?format=markdown
+   -> Full formatted summary
+
+4. GET https://api.timeless.day/v1/meetings/{id}/transcript
+   -> Full speaker-attributed transcript
 ```
 
-Remove a conversation from a room.
+### Workflow 4: Resolve a Shared Link and Read It
 
-#### Example
-
-```bash
-curl -X DELETE "https://my.timeless.day/api/v1/spaces/ROOM_UUID/resources/" \
-  -H "Authorization: Token $TIMELESS_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "resource_type": "CONVERSATION",
-    "resource_uuid": "CONVERSATION_UUID"
-  }'
+```
+1. Decode the /m/ URL (see section 11)
+2. Try GET https://my.timeless.day/api/v1/spaces/{space_uuid}/
+3. If 40x, try GET https://my.timeless.day/api/v1/spaces/{space_uuid}/workspace/?host_uuid={host_uuid}
+4. If 40x, try GET https://my.timeless.day/api/v1/spaces/public/{space_uuid}/{host_uuid}/
+5. From the space response, get conversations and fetch transcripts
 ```
 
-Same request body as Add Resource.
+### Workflow 5: Automate with Webhooks
 
----
+```
+1. POST https://api.timeless.day/v1/webhooks
+   -> Subscribe to meeting.transcript_ready and/or meeting.initial_summary_ready
+   -> Store the secret for signature verification
 
-## Rate Limits
+2. When notified, verify the X-Webhook-Signature header
 
-No official rate limits are documented for the internal API. Be respectful:
-- Add 0.5s delay between sequential requests
-- Don't make more than 60 requests per minute
-- Use pagination instead of fetching everything at once
+3. Fetch the meeting data:
+   GET https://api.timeless.day/v1/meetings/{id}/transcript
+   GET https://api.timeless.day/v1/documents/{doc_id}?format=markdown
 
-## Error Handling
-
-| Code | Meaning |
-|------|---------|
-| 401 | Token expired or invalid. Re-authenticate. |
-| 403 | No access to this resource. Try workspace/public endpoints. |
-| 404 | Resource not found. |
-| 429 | Rate limited. Back off and retry. |
-| 500 | Server error. Retry with exponential backoff. |
+4. Run your automation logic
+```

--- a/scripts/upload.sh
+++ b/scripts/upload.sh
@@ -8,40 +8,38 @@ FILE="${1:?Usage: upload.sh FILE_PATH LANGUAGE [TITLE]}"
 LANG="${2:?Usage: upload.sh FILE_PATH LANGUAGE [TITLE]}"
 TITLE="${3:-$(basename "$FILE" | sed 's/\.[^.]*$//')}"
 TOKEN="${TIMELESS_ACCESS_TOKEN:?TIMELESS_ACCESS_TOKEN not set}"
-BASE="https://my.timeless.day"
+BASE="https://api.timeless.day/v1"
 
-FILENAME=$(basename "$FILE")
-EXT="${FILENAME##*.}"
+EXT="${FILE##*.}"
+EXT=$(echo "$EXT" | tr '[:upper:]' '[:lower:]')
 
 case "$EXT" in
-  mp3) MIME="audio/mpeg" ;;
-  wav) MIME="audio/wav" ;;
-  m4a) MIME="audio/mp4" ;;
-  mp4) MIME="video/mp4" ;;
+  mp3)  MIME="audio/mpeg" ;;
+  wav)  MIME="audio/wav" ;;
+  m4a)  MIME="audio/mp4" ;;
+  mp4)  MIME="video/mp4" ;;
   webm) MIME="audio/webm" ;;
-  ogg) MIME="audio/ogg" ;;
-  *) echo "Unsupported format: $EXT"; exit 1 ;;
+  ogg)  MIME="audio/ogg" ;;
+  aac)  MIME="audio/aac" ;;
+  flac) MIME="audio/flac" ;;
+  mov)  MIME="video/quicktime" ;;
+  *)    echo "Unsupported format: $EXT"; exit 1 ;;
 esac
 
-# Step 1: Presigned URL
-echo "Getting upload URL..."
-PRESIGN=$(curl -s -X POST "$BASE/api/v1/conversation/storage/presigned-url/" \
-  -H "Authorization: Token $TOKEN" \
-  -H "Content-Type: application/json" \
-  -d "{\"file_name\": \"$FILENAME\", \"file_type\": \"$MIME\"}")
-URL=$(echo "$PRESIGN" | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>console.log(JSON.parse(d).url))")
+ENCODED_TITLE=$(printf '%s' "$TITLE" | sed 's/ /%20/g')
 
-# Step 2: Upload
-echo "Uploading $FILENAME..."
-curl -s -X PUT "$URL" -H "Content-Type: $MIME" --upload-file "$FILE" > /dev/null
+echo "Uploading $(basename "$FILE")..."
+RESULT=$(curl -s -X PUT "$BASE/meetings/upload?title=$ENCODED_TITLE&language=$LANG" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: $MIME" \
+  --data-binary @"$FILE")
 
-# Step 3: Process
-echo "Processing..."
-RESULT=$(curl -s -X POST "$BASE/api/v1/conversation/process/media/" \
-  -H "Authorization: Token $TOKEN" \
-  -H "Content-Type: application/json" \
-  -d "{\"language\": \"$LANG\", \"filename\": \"$TITLE\"}")
+MEETING_ID=$(echo "$RESULT" | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
 
-SPACE=$(echo "$RESULT" | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>console.log(JSON.parse(d).space_uuid))")
-echo "Uploaded. Space UUID: $SPACE"
-echo "Poll https://my.timeless.day/api/v1/spaces/$SPACE/ until is_processing=false"
+if [ -z "$MEETING_ID" ]; then
+  echo "Upload failed. Response: $RESULT"
+  exit 1
+fi
+
+echo "Uploaded. Meeting ID: $MEETING_ID"
+echo "Poll https://api.timeless.day/v1/meetings?id=$MEETING_ID until status is completed"

--- a/timeless-api/SKILL.md
+++ b/timeless-api/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: timeless-api
 description: Query and manage Timeless meetings, rooms, transcripts, and AI documents. Capture podcast episodes and YouTube videos into Timeless for transcription. Use when the user asks about their meetings, wants to search meetings, read transcripts, get summaries, list rooms, create rooms, add/remove conversations from rooms, resolve Timeless share links, upload recordings, chat with Timeless AI about meeting content, or capture podcasts/YouTube videos.
-version: 1.0.0
+version: 2.0.0
 metadata:
   openclaw:
     requires:
@@ -27,6 +27,8 @@ Interact with [Timeless](https://timeless.day) meeting data: search meetings, re
 
 For full endpoint documentation with response schemas, status enums, and detailed examples, read `../api-reference.md`.
 
+Official API docs: [docs.timeless.day](https://docs.timeless.day/)
+
 ## Prerequisites
 
 - `TIMELESS_ACCESS_TOKEN` env var (get token at [my.timeless.day/api-token](https://my.timeless.day/api-token))
@@ -37,18 +39,23 @@ Set up in OpenClaw:
 openclaw config patch env.vars.TIMELESS_ACCESS_TOKEN=<your_token>
 ```
 
-## Base URL
+## Base URLs
 
+This skill uses two APIs. Prefer the official API when available.
+
+**Official API** (meetings, rooms, transcripts, recordings, documents, uploads, webhooks):
+```
+https://api.timeless.day/v1
+Authorization: Bearer $TIMELESS_ACCESS_TOKEN
+```
+
+**Unofficial API** (spaces, AI chat, room management, scheduling, share URLs):
 ```
 https://my.timeless.day
-```
-
-## Authentication Header
-
-All requests:
-```
 Authorization: Token $TIMELESS_ACCESS_TOKEN
 ```
+
+> The same `TIMELESS_ACCESS_TOKEN` works for both. The header format differs: `Bearer` for official, `Token` for unofficial.
 
 ---
 
@@ -57,54 +64,105 @@ Authorization: Token $TIMELESS_ACCESS_TOKEN
 ### 1. List Meetings
 
 ```
-GET /api/v1/spaces/meeting/
+GET https://api.timeless.day/v1/meetings
 ```
-
-**Required parameter:** `include` must be `owned` or `shared`.
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `include` | string | **Required.** `owned` or `shared` |
-| `search` | string | Search by title or attendees |
+| `scope` | string | `all` (default), `owned`, or `shared` |
+| `search` | string | Search by meeting title (substring match) |
+| `q` | string | Semantic search across meeting content |
 | `start_date` | string | From date (YYYY-MM-DD) |
 | `end_date` | string | To date (YYYY-MM-DD) |
-| `status` | string | `COMPLETED`, `SCHEDULED`, `PROCESSING`, `FAILED` |
-| `page` | integer | Page number (default: 1) |
-| `per_page` | integer | Results per page (default: 20) |
+| `status` | string | `completed`, `processing`, `scheduled`, `failed` |
+| `participant` | string | Filter by participant name or email |
+| `company` | string | Filter by company name or domain |
+| `room_id` | string | Filter by room ID (e.g. `room_abc123`) |
+| `expand` | string | `documents` to include AI documents inline |
+| `limit` | integer | Results per page, 1-100 (default: 25) |
+| `cursor` | string | Pagination cursor from previous response |
 
 ```bash
-curl -s "https://my.timeless.day/api/v1/spaces/meeting/?include=owned&status=COMPLETED&per_page=50" \
-  -H "Authorization: Token $TIMELESS_ACCESS_TOKEN"
+curl -s "https://api.timeless.day/v1/meetings?scope=owned&status=completed&limit=50" \
+  -H "Authorization: Bearer $TIMELESS_ACCESS_TOKEN"
 ```
 
-**Response:** `{ count, next, previous, results: [{ uuid, title, start_ts, end_ts, status, primary_conversation_uuid, host_user, conversation_source, created_at }] }`
+**Response:**
+```json
+{
+  "data": [
+    {
+      "id": "mtg_abc123",
+      "title": "Weekly standup",
+      "status": "completed",
+      "source": "google_meet",
+      "start_time": "2025-01-15T10:00:00Z",
+      "end_time": "2025-01-15T10:30:00Z",
+      "duration": 1800,
+      "host": { "id": "usr_def456", "name": "Alice Johnson", "email": "alice@example.com" },
+      "participants": [
+        { "name": "Bob Smith", "email": "bob@example.com", "title": "Engineer", "company": "Acme Corp" }
+      ],
+      "created_at": "2025-01-15T10:00:00Z"
+    }
+  ],
+  "next_cursor": "eyJjcmVhdGVkX2F0Ijo...",
+  "has_more": true
+}
+```
 
 **Key fields:**
-- `uuid` = space UUID (for Get Space)
-- `primary_conversation_uuid` = conversation UUID (for Get Transcript)
+- `id` = meeting ID (use for Get Transcript, Get Recording, Get Document)
+- Use `scope=all` to get both owned and shared meetings in one call
 
-> To get ALL meetings, make two calls: `include=owned` and `include=shared`, then merge.
+**Pagination:** pass `next_cursor` as `cursor` param to get the next page. Repeat while `has_more` is `true`.
 
 ---
 
 ### 2. List Rooms
 
 ```
-GET /api/v1/spaces/room/
+GET https://api.timeless.day/v1/rooms
 ```
 
-Same query parameters as List Meetings (except rooms don't have `start_ts`, `end_ts`, or `status`).
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `scope` | string | `all` (default), `owned`, or `shared` |
+| `search` | string | Search by room title |
+| `expand` | string | `documents`, `meetings`, or both (`expand=documents&expand=meetings`) |
+| `limit` | integer | Results per page, 1-100 (default: 25) |
+| `cursor` | string | Pagination cursor from previous response |
 
 ```bash
-curl -s "https://my.timeless.day/api/v1/spaces/room/?include=owned" \
-  -H "Authorization: Token $TIMELESS_ACCESS_TOKEN"
+curl -s "https://api.timeless.day/v1/rooms?scope=owned&expand=meetings" \
+  -H "Authorization: Bearer $TIMELESS_ACCESS_TOKEN"
 ```
 
-**Response:** `{ count, next, previous, results: [{ uuid, title, host_user, created_at }] }`
+**Response:**
+```json
+{
+  "data": [
+    {
+      "id": "room_abc123",
+      "title": "Engineering standups",
+      "created_at": "2025-01-01T00:00:00Z",
+      "updated_at": "2025-01-15T10:30:00Z",
+      "meeting_count": 42,
+      "meetings": [
+        { "id": "mtg_abc123", "title": "Weekly standup", "status": "completed", "source": "google_meet", "start_time": "2025-01-15T10:00:00Z", "duration": 1800 }
+      ]
+    }
+  ],
+  "next_cursor": null,
+  "has_more": false
+}
+```
 
 ---
 
-### 3. Get Space (Meeting or Room Details)
+### 3. Get Space (Meeting or Room Details) — Unofficial API
+
+> This endpoint uses the **unofficial API** (`https://my.timeless.day`) and returns rich data not available via the official API: conversations, artifacts, contacts, organizations, and AI chat threads.
 
 Spaces have three access levels. **Try in order until one succeeds:**
 
@@ -145,83 +203,106 @@ Deduplicate conversation UUIDs from `conversations[]` + `contacts[].conversation
 
 ### 4. Get Transcript
 
+```
+GET https://api.timeless.day/v1/meetings/{meeting_id}/transcript
+```
+
 ```bash
-curl -s "https://my.timeless.day/api/v1/conversation/{conversation_uuid}/transcript/" \
-  -H "Authorization: Token $TIMELESS_ACCESS_TOKEN"
+curl -s "https://api.timeless.day/v1/meetings/mtg_abc123/transcript" \
+  -H "Authorization: Bearer $TIMELESS_ACCESS_TOKEN"
 ```
 
 **Response:**
 ```json
 {
-  "items": [
-    { "text": "...", "start_time": 0.5, "end_time": 3.2, "speaker_id": "speaker_0" }
-  ],
+  "meeting_id": "mtg_abc123",
+  "language": "en",
   "speakers": [
-    { "id": "speaker_0", "name": "Alice Johnson" }
+    { "id": "spk_001", "name": "Alice Johnson" },
+    { "id": "spk_002", "name": "Bob Smith" }
   ],
-  "language": "he"
+  "segments": [
+    { "speaker_id": "spk_001", "start_time": 0, "end_time": 4.5, "text": "Good morning everyone, let's get started." },
+    { "speaker_id": "spk_002", "start_time": 4.8, "end_time": 8.2, "text": "Sounds good. I have updates on the project." }
+  ]
 }
 ```
 
-**How to get conversation_uuid:**
-- From List Meetings: `primary_conversation_uuid` field
-- From Get Space: `conversations[].uuid`
+**How to get meeting_id:** from the `id` field in List Meetings response.
 
 **Format as readable text** by mapping `speaker_id` to speaker names:
 ```
-[00:00:00] Alice Johnson: ...
-[00:00:03] Bob Smith: ...
+[00:00:00] Alice Johnson: Good morning everyone, let's get started.
+[00:00:04] Bob Smith: Sounds good. I have updates on the project.
 ```
+
+> **For room conversations:** To fetch transcripts for individual conversations within a room (accessed via Get Space), use the unofficial transcript endpoint: `GET https://my.timeless.day/api/v1/conversation/{conversation_uuid}/transcript/` with `Authorization: Token`.
 
 ---
 
 ### 5. Get Recording URL
 
-```bash
-curl -s "https://my.timeless.day/api/v1/conversation/{conversation_uuid}/recording/" \
-  -H "Authorization: Token $TIMELESS_ACCESS_TOKEN"
+```
+GET https://api.timeless.day/v1/meetings/{meeting_id}/recording
 ```
 
-**Response:** `{ "media_url": "https://storage.googleapis.com/...signed..." }`
+```bash
+curl -s "https://api.timeless.day/v1/meetings/mtg_abc123/recording" \
+  -H "Authorization: Bearer $TIMELESS_ACCESS_TOKEN"
+```
 
-> The URL is time-limited. Fetch it fresh when needed.
+**Response:**
+```json
+{
+  "meeting_id": "mtg_abc123",
+  "recording_url": "https://storage.example.com/recordings/abc123?token=..."
+}
+```
+
+> The URL is time-limited. Fetch it fresh when needed. `recording_url` is `null` if no recording is available.
 
 ---
 
 ### 6. Upload a Recording
 
-Three-step flow:
-
-```bash
-# Step 1: Get presigned URL
-curl -X POST "https://my.timeless.day/api/v1/conversation/storage/presigned-url/" \
-  -H "Authorization: Token $TIMELESS_ACCESS_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"file_name": "recording.mp3", "file_type": "audio/mpeg"}'
-
-# Step 2: Upload file to the presigned URL
-curl -X PUT "PRESIGNED_URL" \
-  -H "Content-Type: audio/mpeg" \
-  --upload-file recording.mp3
-
-# Step 3: Trigger processing
-curl -X POST "https://my.timeless.day/api/v1/conversation/process/media/" \
-  -H "Authorization: Token $TIMELESS_ACCESS_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"language": "he", "filename": "Recording Title"}'
+```
+PUT https://api.timeless.day/v1/meetings/upload
 ```
 
-**Response (step 3):** `{ "event_uuid": "...", "space_uuid": "..." }`
+Single-step upload: send the raw file as the request body with metadata as query parameters.
 
-Poll `GET /api/v1/spaces/{space_uuid}/` until `is_processing` is `false`.
+| Parameter | Location | Description |
+|-----------|----------|-------------|
+| `title` | query | Optional title for the recording (max 500 chars) |
+| `language` | query | Language code for transcription (e.g. `en`, `es`) |
+| `Content-Type` | header | MIME type of the file |
+
+**Supported types:** `audio/mpeg`, `audio/mp4`, `audio/wav`, `audio/webm`, `audio/ogg`, `audio/aac`, `audio/flac`, `video/mp4`, `video/webm`, `video/ogg`, `video/quicktime`
+
+```bash
+curl -X PUT "https://api.timeless.day/v1/meetings/upload?title=Team%20sync&language=en" \
+  -H "Authorization: Bearer $TIMELESS_ACCESS_TOKEN" \
+  -H "Content-Type: audio/mpeg" \
+  --data-binary @recording.mp3
+```
+
+**Response:**
+```json
+{
+  "id": "mtg_abc123",
+  "status": "processing"
+}
+```
+
+Poll `GET /meetings?id=mtg_abc123` until `status` changes from `processing` to `completed`.
 
 Or use the helper script: `bash ../scripts/upload.sh FILE_PATH LANGUAGE [TITLE]`
 
-**Supported formats:** mp3, wav, m4a, mp4, webm, ogg
+**Supported file extensions:** mp3, wav, m4a, mp4, webm, ogg, aac, flac, mov
 
 ---
 
-### 7. Resolve a Timeless Share URL
+### 7. Resolve a Timeless Share URL — Unofficial API
 
 URLs like `https://my.timeless.day/m/ENCODED_ID` contain two Base64-encoded short IDs (22 chars each).
 
@@ -247,7 +328,7 @@ After decoding, fetch with Get Space (try private -> workspace -> public).
 
 ---
 
-### 8. Chat with Timeless AI
+### 8. Chat with Timeless AI — Unofficial API
 
 Ask questions about a meeting or room.
 
@@ -283,7 +364,7 @@ Poll every 2-3 seconds until `is_running` is `false`. The AI response is the las
 
 ---
 
-### 9. Create a Room
+### 9. Create a Room — Unofficial API
 
 ```bash
 curl -X POST "https://my.timeless.day/api/v1/spaces/" \
@@ -296,7 +377,7 @@ curl -X POST "https://my.timeless.day/api/v1/spaces/" \
 
 ---
 
-### 10. Add/Remove Conversations from a Room
+### 10. Add/Remove Conversations from a Room — Unofficial API
 
 ```bash
 # Add a conversation
@@ -312,57 +393,161 @@ curl -X DELETE "https://my.timeless.day/api/v1/spaces/{room_uuid}/resources/" \
   -d '{"resource_type": "CONVERSATION", "resource_uuid": "CONVERSATION_UUID"}'
 ```
 
-Call Add once per conversation you want to attach. Get conversation UUIDs from List Meetings (`primary_conversation_uuid`) or Get Space (`conversations[].uuid`).
+Call Add once per conversation you want to attach. Get conversation UUIDs from Get Space (`conversations[].uuid`).
+
+---
+
+### 11. Get Document
+
+```
+GET https://api.timeless.day/v1/documents/{document_id}
+```
+
+Fetch an AI-generated document (summary, action items, notes) in your preferred format.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `format` | string | `html` (default), `markdown`, `raw`, `docx`, `json` |
+
+```bash
+curl -s "https://api.timeless.day/v1/documents/doc_abc123?format=markdown" \
+  -H "Authorization: Bearer $TIMELESS_ACCESS_TOKEN"
+```
+
+**Response:**
+```json
+{
+  "id": "doc_abc123",
+  "title": "Meeting summary",
+  "format": "markdown",
+  "content": "# Weekly standup\n\n## Key decisions\n- Proceed with the new API design\n\n## Action items\n- Alice: Update the spec by Friday\n",
+  "created_at": "2025-01-15T10:35:00Z"
+}
+```
+
+**How to get document IDs:** Use `expand=documents` when listing meetings or rooms. Each meeting/room will include a `documents[]` array with `id`, `title`, and `created_at`.
+
+---
+
+### 12. Webhooks
+
+Subscribe to events so Timeless notifies you when transcripts or summaries are ready.
+
+**Available events:** `meeting.transcript_ready`, `meeting.initial_summary_ready`
+
+#### Create a Webhook
+
+```bash
+curl -X POST "https://api.timeless.day/v1/webhooks" \
+  -H "Authorization: Bearer $TIMELESS_ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "url": "https://example.com/webhooks/timeless",
+    "events": ["meeting.transcript_ready", "meeting.initial_summary_ready"]
+  }'
+```
+
+**Response:** Returns the webhook object including a `secret` for signature verification. Store the secret securely; it is only returned at creation time.
+
+#### List Webhooks
+
+```bash
+curl -s "https://api.timeless.day/v1/webhooks" \
+  -H "Authorization: Bearer $TIMELESS_ACCESS_TOKEN"
+```
+
+#### Update a Webhook
+
+```bash
+curl -X PATCH "https://api.timeless.day/v1/webhooks/whk_abc123" \
+  -H "Authorization: Bearer $TIMELESS_ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"enabled": false}'
+```
+
+#### Delete a Webhook
+
+```bash
+curl -X DELETE "https://api.timeless.day/v1/webhooks/whk_abc123" \
+  -H "Authorization: Bearer $TIMELESS_ACCESS_TOKEN"
+```
+
+#### Verifying Webhook Signatures
+
+Every delivery includes an `X-Webhook-Signature` header (`sha256=<hex digest>`). Verify using HMAC-SHA256 with your webhook secret:
+
+```python
+import hashlib, hmac
+
+def verify_signature(payload: bytes, signature_header: str, secret: str) -> bool:
+    expected = hmac.new(secret.encode(), payload, hashlib.sha256).hexdigest()
+    received = signature_header.removeprefix("sha256=")
+    return hmac.compare_digest(expected, received)
+```
+
+**Delivery behavior:** 10s timeout, retries up to 3 times (1s, 10s, 60s) on 5xx/429/network failures.
 
 ---
 
 ## Common Workflows
 
 ### Export All Transcripts
-1. List all meetings with `include=owned&status=COMPLETED&per_page=100`
-2. Paginate through all pages
-3. For each meeting, fetch transcript using `primary_conversation_uuid`
+1. List all meetings: `GET /meetings?scope=owned&status=completed&limit=100`
+2. Paginate through all pages using `next_cursor`
+3. For each meeting, fetch transcript using its `id`
+
+### Get Meeting Summary
+1. List meetings with documents: `GET /meetings?scope=owned&status=completed&expand=documents`
+2. From the meeting's `documents[]`, find the document you want
+3. Fetch the full content: `GET /documents/{document_id}?format=markdown`
 
 ### Get Everything from a Room
-1. Get Space for the room UUID
+1. Get Space for the room UUID (unofficial API)
 2. Collect all conversation UUIDs from `conversations[]`, `contacts[].conversations[]`, `organizations[].conversations[]` (deduplicate)
-3. Fetch transcript for each conversation UUID
+3. Fetch transcript for each conversation UUID using the unofficial transcript endpoint
 
 ### Search and Read
-1. List meetings with `search=your+query`
-2. Pick the meeting, get its `primary_conversation_uuid`
-3. Fetch transcript
-4. Optionally, Get Space for AI summaries in `artifacts[]`
+1. List meetings with `search=your+query` or use semantic search with `q=your+question`
+2. Pick the meeting, get its `id`
+3. Fetch transcript: `GET /meetings/{id}/transcript`
+4. Fetch AI summary: use `expand=documents` in the list call, then `GET /documents/{doc_id}?format=markdown`
 
 ---
 
 ## Automation Patterns
 
-Timeless does not have webhooks yet. To build automations that react to new meetings, use **cron polling with a state file**.
+### Webhooks (Recommended)
 
-### The Pattern: Poll, Deduplicate, Act
+Use webhooks to react to new meetings automatically without polling.
+
+1. Create a webhook: `POST /webhooks` with your URL and desired events
+2. When a meeting transcript is ready, Timeless sends a POST to your URL with the meeting data
+3. Verify the signature, then process the meeting (fetch transcript, documents, etc.)
+
+### Cron Polling (Fallback)
+
+For environments that cannot receive webhooks, use **cron polling with a state file**.
 
 A cron job runs every 5-10 minutes. Each run:
 
 1. Read a state file (`timeless-processed.json`). Create it with an empty `processed` array if missing.
-2. Poll for completed meetings: `GET /api/v1/spaces/meeting/?include=owned&status=COMPLETED&start_date=YYYY-MM-DD`
-3. For each meeting: if its `uuid` is already in `processed`, skip it.
-4. For new meetings: fetch whatever data you need (transcript, space details, artifacts), then run your automation logic.
-5. Append processed UUIDs to the state file.
+2. Poll for completed meetings: `GET https://api.timeless.day/v1/meetings?scope=owned&status=completed&start_date=YYYY-MM-DD`
+3. For each meeting: if its `id` is already in `processed`, skip it.
+4. For new meetings: fetch whatever data you need (transcript, documents, space details), then run your automation logic.
+5. Append processed IDs to the state file.
 6. **If nothing is new, exit silently.** Do not message the user.
 
 **State file format:**
 ```json
 {
-  "processed": ["uuid-1", "uuid-2", "uuid-3"],
+  "processed": ["mtg_abc123", "mtg_def456"],
   "last_check": "2026-03-05T12:00:00Z"
 }
 ```
 
 **Key rules:**
-- A UUID in `processed` is never processed again. This prevents duplicate work.
-- Periodically prune old UUIDs (e.g., older than 30 days) to keep the file small.
-- Also fetch `include=shared` if the automation should cover meetings shared with you.
+- An ID in `processed` is never processed again. This prevents duplicate work.
+- Periodically prune old IDs (e.g., older than 30 days) to keep the file small.
 
 **Cron setup (OpenClaw):**
 ```
@@ -371,10 +556,10 @@ openclaw cron add "timeless-poll" --schedule "*/5 * * * *" --task "Check for new
 
 ### What You Can Do With a New Meeting
 
-Once the polling pattern detects a new completed meeting, you have access to:
+Once a new completed meeting is detected (via webhook or polling), you have access to:
 - **Transcript** (full speaker-attributed text via Get Transcript)
-- **AI summary and action items** (via Get Space `artifacts[]`)
-- **Participants and metadata** (via Get Space `conversations[].event.attendees`)
+- **AI summary and documents** (via Get Document or Get Space `artifacts[]`)
+- **Participants and metadata** (from the meeting object or Get Space)
 - **Recording URL** (via Get Recording)
 - **AI chat** (ask follow-up questions via Chat with Timeless AI)
 
@@ -387,7 +572,7 @@ Combine these with any external tool or API. Some examples of what people build:
 - Run sentiment analysis or extract custom fields from transcripts
 - Build a searchable meeting knowledge base
 
-The pattern is always the same: poll for new meetings, pull the data, do your thing.
+The pattern is always the same: detect new meetings, pull the data, do your thing.
 
 ---
 
@@ -425,11 +610,11 @@ Downloads as mp4 (video+audio). No ffmpeg needed. Uses the best pre-muxed format
 
 After uploading, attach the content to a Timeless room for organized collections.
 
-1. Upload returns a `space_uuid`. Poll `GET /api/v1/spaces/{space_uuid}/` until `is_processing=false`.
-2. From the space response, get the `conversation.uuid`.
-3. Add to room: `POST /api/v1/spaces/{room_uuid}/resources/` with `{"resource_type": "CONVERSATION", "resource_uuid": "CONV_UUID"}`
+1. Upload returns a meeting `id`. Poll `GET https://api.timeless.day/v1/meetings?id={meeting_id}` until `status` is `completed`.
+2. To get the conversation UUID, fetch the space via the unofficial API: `GET https://my.timeless.day/api/v1/spaces/{uuid}/` and extract `conversations[0].uuid`.
+3. Add to room: `POST https://my.timeless.day/api/v1/spaces/{room_uuid}/resources/` with `{"resource_type": "CONVERSATION", "resource_uuid": "CONV_UUID"}`
 
-To create a new room first: `POST /api/v1/spaces/` with `{"has_onboarded": true, "space_type": "ROOM", "title": "My Collection"}`
+To create a new room first: `POST https://my.timeless.day/api/v1/spaces/` with `{"has_onboarded": true, "space_type": "ROOM", "title": "My Collection"}`
 
 ---
 
@@ -439,21 +624,34 @@ To create a new room first: `POST /api/v1/spaces/` with `{"has_onboarded": true,
 - YouTube downloads require yt-dlp. If not installed, the script will fail with a clear error.
 - Always clean up downloaded files from /tmp after uploading.
 - Set `YTDLP_PATH` env var if yt-dlp is not on PATH.
+- Official API uses prefixed IDs (`mtg_`, `room_`, `doc_`, `whk_`). Unofficial API uses plain UUIDs. Do not mix them across APIs.
 
 ---
 
 ## Error Handling
 
+**Official API** returns structured errors:
+```json
+{ "error": { "code": "not_found", "message": "Resource not found" } }
+```
+
 | Code | Action |
 |------|--------|
 | 401 | Token expired. Re-authenticate at my.timeless.day/api-token |
-| 403 | No access. Try workspace or public endpoint. |
-| 404 | Not found. Check UUID. |
-| 429 | Rate limited. Wait and retry. |
+| 403 | No access. For unofficial API, try workspace or public endpoint. |
+| 404 | Not found. Check ID/UUID. |
+| 429 | Rate limited. Check `Retry-After` header and wait. |
 
 ## Rate Limiting
 
-No official limits, but be respectful:
-- 0.5s delay between sequential requests
-- Max ~60 requests per minute
-- Use pagination, don't fetch everything at once
+**Official API** includes rate limit headers on every response:
+
+| Endpoint | Limit |
+|----------|-------|
+| Most endpoints | 60 requests/minute |
+| Webhook creation | 20 requests/minute |
+| File upload | 10 requests/minute |
+
+Headers: `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`
+
+**Unofficial API:** No official limits. Be respectful: 0.5s delay between sequential requests, max ~60 requests per minute.


### PR DESCRIPTION
## Summary

- Migrate core endpoints (list meetings, list rooms, get transcript, get recording, upload) from the unofficial API (`my.timeless.day`) to the official API (`api.timeless.day/v1`) with `Bearer` auth, cursor-based pagination, and prefixed resource IDs
- Add new official API capabilities: Get Document endpoint (multi-format: markdown, html, raw, docx, json) and webhook subscriptions (`meeting.transcript_ready`, `meeting.initial_summary_ready`) for automated workflows
- Preserve all unofficial-only features: Get Space (conversations, artifacts, contacts, orgs, threads), AI chat, room management (create/add/remove), share URL resolution, and scheduling

### Files changed

| File | Change |
|------|--------|
| `timeless-api/SKILL.md` | Dual base URLs, migrated ops 1/2/4/5/6 to official API, added ops 11 (documents) and 12 (webhooks), updated workflows and automation patterns |
| `api-reference.md` | Restructured into Part 1 (Official API) and Part 2 (Unofficial API), standardized `TIMELESS_ACCESS_TOKEN` everywhere |
| `scripts/upload.sh` | Rewritten from 3-step presigned URL flow to single-step `PUT /meetings/upload` |
| `README.md` | Added official API docs link and webhook mention |

### No changes needed

- `timeless-scheduling/SKILL.md` -- only uses unofficial endpoints (`GET /users/`, `POST /invite/`)
- `scripts/podcast.sh`, `scripts/youtube.sh` -- download/search logic, no Timeless API calls

## Test plan

- [ ] Verify `upload.sh` works with the official upload endpoint (`PUT /meetings/upload`)
- [ ] Verify list meetings via official API returns expected response shape
- [ ] Verify transcript fetch by meeting ID works
- [ ] Verify Get Space, AI chat, and room management still work on unofficial API
- [ ] Verify webhook creation and delivery

Made with [Cursor](https://cursor.com)